### PR TITLE
Correct example for issue 18

### DIFF
--- a/src/mount_lite_18/core.clj
+++ b/src/mount_lite_18/core.clj
@@ -7,5 +7,6 @@
   "I don't do a whole lot."
   [& args]
   (prn (mount/status))
-  (prn (namespace-deps/start))
+  ;; Start up to a, should also start c because it's needed for a
+  (prn (namespace-deps/start #'mount-lite-18.a/a))
   (prn (mount/status)))


### PR DESCRIPTION
Provide example to illustrate https://github.com/aroemers/mount-lite/issues/18.

```
$ lein run
{#'mount-lite-18.c/c :stopped, #'mount-lite-18.a/a :stopped}
(#'mount-lite-18.a/a)
{#'mount-lite-18.c/c :stopped, #'mount-lite-18.a/a :started}
```

`mount-lite-18.c/c` is stopped after starting the app up to `mount-lite-18.a/a`, even though everything should be started.